### PR TITLE
Testing

### DIFF
--- a/representer.cpp
+++ b/representer.cpp
@@ -1,0 +1,37 @@
+#include <clang-c/Index.h>
+
+#include <fstream>
+#include <iostream>
+
+static int counter = 1;
+static std::ofstream ostrm;
+
+int main() {
+  CXIndex idx = clang_createIndex(0, 0);
+  CXTranslationUnit tu = clang_parseTranslationUnit(
+      idx, "test.c", nullptr, 0, nullptr, 0, CXTranslationUnit_None);
+  if (tu == nullptr) {
+    return 1;
+  }
+  CXCursor cursor = clang_getTranslationUnitCursor(tu);
+  ostrm.open("replace.txt");
+  clang_visitChildren(
+      cursor,
+      [](CXCursor cursor, CXCursor parent, CXClientData client_data) {
+        CXSourceLocation location = clang_getCursorLocation(cursor);
+        if (!clang_Location_isFromMainFile(location)) {
+          return CXChildVisit_Recurse;
+        }
+        CXCursorKind kind = clang_getCursorKind(cursor);
+        if (kind == CXCursor_VarDecl) {
+          CXString spelling = clang_getCursorSpelling(cursor);
+          ostrm << "PLACEHOLDER_" << counter++ << ' ';
+          ostrm << clang_getCString(spelling) << '\n';
+          clang_disposeString(spelling);
+        }
+        return CXChildVisit_Recurse;
+      },
+      nullptr);
+  clang_disposeTranslationUnit(tu);
+  clang_disposeIndex(idx);
+}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+clang++ representer.cpp -lclang
+./a.out
+clang -cc1 -ast-print test.c > representation.txt
+while read i j; do sed -i "s/$j/$i/g" representation.txt; done < replace.txt

--- a/test.c
+++ b/test.c
@@ -1,0 +1,5 @@
+int main(void) {
+    int foo = 3;
+    int bar = 5;
+    return 0;
+}


### PR DESCRIPTION
This is some ugly code, but I just wanted to share something to see what you think.

I'm using `libclang` to output variable names and the placeholder name to a file, `replace.txt`.
Then I'm dumping the content of the `.c` file using `-ast-print`.
After that I'm using `sed` to replace all the variable names with the placeholder names using `replace.txt`.

This should give a normalized representation with placeholder names. It will ofc have to be extended to handle function names and what not, but you get the idea. Also it doesn't handle duplicate variable names.

@wolf99 What do you think, is this something to work from, or should we approach this in a different way?